### PR TITLE
Bump beefcake version to allow unicode logs

### DIFF
--- a/loggregator_emitter.gemspec
+++ b/loggregator_emitter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
-  spec.add_dependency "beefcake", "~> 0.3.7"
+  spec.add_dependency "beefcake", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.0"

--- a/spec/loggregator_emitter/emit_spec.rb
+++ b/spec/loggregator_emitter/emit_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "spec_helper"
 require "support/fake_loggregator_server"
 require "loggregator_emitter"
@@ -193,6 +194,18 @@ describe LoggregatorEmitter do
         sleep 0.5
         messages = @server.messages
         expect(messages.length).to eq 4
+      end
+
+      it "sends messages with unicode characters " do
+        emitter = make_emitter("localhost")
+        message = "測試".encode("utf-8")
+        emitter.send(emit_method, "my_app_id", message)
+
+        sleep 0.5
+
+        messages = @server.messages
+        expect(messages.length).to eq 1
+        expect(messages[0].message.force_encoding("utf-8")).to eq "測試"
       end
     end
   end


### PR DESCRIPTION
Any CF operation that happens to emit unicode characters ends up with a 500 Internal Server Error.
